### PR TITLE
feat(model): implement Song dataclass (#12)

### DIFF
--- a/broken-tunes-backend/app/models/Song.py
+++ b/broken-tunes-backend/app/models/Song.py
@@ -1,0 +1,48 @@
+
+# Song model for songs view
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass
+class Song:
+    """
+    Representa una canción de la VIEW 'songs'.
+    La VIEW une songs_data + artists, por eso artist es string y no FK.
+
+    Columnas de la VIEW:
+        songs_data.id, songs_data.title, artists.name AS artist,
+        songs_data.mp3_data, songs_data.created_at
+    """
+    id:         int
+    title:      str
+    artist:     str
+    mp3_data:   Optional[bytes] = None
+    created_at: Optional[datetime] = None
+
+    def to_dict(self) -> dict:
+        """
+        Serializa la canción para respuestas JSON.
+        Excluye mp3_data — los bytes de audio se sirven por /play/<id>.
+        """
+        return {
+            'id':         self.id,
+            'title':      self.title,
+            'artist':     self.artist,
+            'created_at': self.created_at.isoformat() if self.created_at else None,
+        }
+
+    @staticmethod
+    def from_row(row: tuple) -> 'Song':
+        """
+        Construye un Song desde una tupla cruda de MySQL.
+        Espera el orden: (id, title, artist, mp3_data, created_at)
+        """
+        return Song(
+            id=row[0],
+            title=row[1],
+            artist=row[2],
+            mp3_data=bytes(row[3]) if row[3] else None,
+            created_at=row[4] if len(row) > 4 else None,
+        )


### PR DESCRIPTION
Resumen (1 frase)
Se implementa el modelo Song como dataclass para representar las canciones provenientes de la vista songs.

Tipo de cambio
[ ] Fix (corrección de bug)
[X] Feat (nueva funcionalidad)
[ ] Refactor (cambios internos sin cambiar comportamiento)
[ ] Docs (documentación)
[ ] Chore/CI (configuración, dependencias, pipeline)
[ ] Perf (mejora de rendimiento)
[ ] Test (tests)
[ ] No sé
Contexto / Problema
El backend necesitaba un modelo que representara las canciones obtenidas desde la vista songs en la base de datos.

Sin este modelo no era posible estructurar correctamente los datos provenientes de MySQL ni serializarlos de forma consistente para las respuestas JSON del API.

Solución propuesta
Antes:
No existía un modelo que representara las canciones de la base de datos.

Después:
Se implementó una dataclass Song que:

Representa una canción de la vista songs

Permite convertir filas de MySQL a objetos Song

Permite serializar la información a JSON

Excluye mp3_data del JSON para evitar enviar audio en las respuestas

Cómo probarlo (pasos)
Ejecutar la aplicación backend.

Consumir el endpoint:

GET /api/songs

Verificar que la respuesta devuelve un JSON con los campos:

id
title
artist
created_at

Confirmar que mp3_data no aparece en la respuesta JSON.

Evidencia
Capturas/GIF: No aplica
Logs: No sé
Impacto / Riesgos
Cambios rompientes (breaking): No
Migraciones / scripts: No aplica
Seguridad / Privacidad: No sé
Riesgo percibido
[ x] Bajo
 Medio
 Alto
Motivo (opcional): No sé
Checklist antes de pedir review
[X] Probé localmente los casos principales
[ ] Agregué/actualicé tests o marqué “No aplica”
[X] Pasé linters/formatters (si existen)
[ ] Actualicé documentación/README si corresponde
[X] Vinculé issues: closes #12 
[X] Añadí plan de QA o pasos reproducibles
Notas para quien revisa (opcional)
Archivos clave: Módulo de carga de biblioteca
Dudas: No aplica
- label: Baja (cosmético, no afecta uso)
- label: Media (afecta funcionalidad, pero hay workaround)
- label: Alta (bloquea uso normal o causa pérdida de datos)
validations:
required: true