### PR TITLE
feat(model): implement Backup dataclass (#13)

### DIFF
--- a/broken-tunes-backend/app/models/Backup.py
+++ b/broken-tunes-backend/app/models/Backup.py
@@ -1,0 +1,60 @@
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+
+@dataclass
+class Backup:
+    """
+    Representa un backup de la tabla 'songs_backup'.
+
+    Columnas:
+        id, original_song_id, title, artist, mp3_data,
+        backup_note, backed_up_by, backed_up_at
+    """
+    id:               int
+    title:            str
+    artist:           str
+    original_song_id: Optional[int]      = None
+    mp3_data:         Optional[bytes]    = None
+    backup_note:      str                = 'periodic backup'
+    backed_up_by:     str                = 'system'
+    backed_up_at:     Optional[datetime] = None
+
+    def to_dict(self) -> dict:
+        """
+        Serializa el backup para respuestas JSON.
+        Excluye mp3_data — los bytes se sirven por /play_backup/<id>.
+        backed_up_at se convierte a ISO 8601 si es datetime.
+        """
+        return {
+            'id':               self.id,
+            'original_song_id': self.original_song_id,
+            'title':            self.title,
+            'artist':           self.artist,
+            'backup_note':      self.backup_note,
+            'backed_up_by':     self.backed_up_by,
+            'backed_up_at':     (
+                self.backed_up_at.isoformat()
+                if isinstance(self.backed_up_at, datetime)
+                else self.backed_up_at
+            ),
+        }
+
+    @staticmethod
+    def from_row(row: tuple) -> 'Backup':
+        """
+        Construye un Backup desde una tupla cruda de MySQL.
+        Espera el orden:
+            (id, original_song_id, title, artist,
+             backup_note, backed_up_by, backed_up_at)
+        """
+        return Backup(
+            id=               row[0],
+            original_song_id= row[1],
+            title=            row[2],
+            artist=           row[3],
+            backup_note=      row[4] or 'periodic backup',
+            backed_up_by=     row[5] or 'system',
+            backed_up_at=     row[6],
+        )


### PR DESCRIPTION
Resumen (1 frase)
Se implementa el modelo Backup como dataclass para representar los respaldos de canciones almacenados en la tabla songs_backup.

Tipo de cambio
[ ] Fix (corrección de bug)
[X] Feat (nueva funcionalidad)
[ ] Refactor (cambios internos sin cambiar comportamiento)
[ ] Docs (documentación)
[ ] Chore/CI (configuración, dependencias, pipeline)
[ ] Perf (mejora de rendimiento)
[ ] Test (tests)
[ ] No sé
Contexto / Problema
El backend requiere un modelo que represente los respaldos de canciones almacenados en la tabla songs_backup.

Sin este modelo no es posible mapear correctamente los registros de respaldo provenientes de MySQL ni serializar su información de forma consistente para el API.

Solución propuesta
Antes:
No existía un modelo que representara los respaldos de canciones.

Después:
Se implementó una dataclass Backup que:

Representa un registro de respaldo de la tabla songs_backup

Permite convertir filas de MySQL a objetos Backup

Permite serializar la información a JSON

Serializa la fecha backed_up_at en formato ISO

Cómo probarlo (pasos)
Ejecutar el backend.

Simular una consulta a la tabla songs_backup.

Convertir la fila obtenida desde MySQL usando Backup.from_row().

Serializar el objeto con to_dict().

Verificar que el campo backed_up_at se devuelva en formato ISO.

Evidencia
Capturas/GIF: No aplica
Logs: No sé
Impacto / Riesgos
Cambios rompientes (breaking): No
Migraciones / scripts: No aplica
Seguridad / Privacidad: No sé
Riesgo percibido
[ x] Bajo
Medio
Alto
Motivo (opcional): No sé
Checklist antes de pedir review
[X] Probé localmente los casos principales
[ ] Agregué/actualicé tests o marqué “No aplica”
[X] Pasé linters/formatters (si existen)
[ ] Actualicé documentación/README si corresponde
[X] Vinculé issues: closes #13 
[X] Añadí plan de QA o pasos reproducibles
Notas para quien revisa (opcional)
Archivos clave: Módulo de carga de biblioteca
Dudas: No aplica

label: Baja (cosmético, no afecta uso)
label: Media (afecta funcionalidad, pero hay workaround)
label: Alta (bloquea uso normal o causa pérdida de datos)
validations:
required: true