### PR TITLE
feat(repository): implement SongRepository (#14)

### DIFF
--- a/broken-tunes-backend/app/repositories/Song_repository.py
+++ b/broken-tunes-backend/app/repositories/Song_repository.py
@@ -1,0 +1,57 @@
+from typing import Optional
+from app.database import get_db
+from app.models.Song import Song
+
+
+class SongRepository:
+    """
+    Único punto de acceso a datos de la tabla/view 'songs'.
+    Todas las queries relacionadas a canciones viven aquí.
+    """
+
+    def get_all(self) -> list[Song]:
+        """
+        Retorna todas las canciones que tienen audio válido.
+        Replica el FIX BUG #14: filtra mp3_data nulo o muy corto.
+
+        Returns:
+            list[Song]: Lista de canciones sin mp3_data (solo metadata).
+        """
+        conn = get_db()
+        try:
+            cur = conn.cursor()
+            cur.execute("""
+                SELECT id, title, artist, mp3_data, created_at
+                FROM songs
+                WHERE mp3_data IS NOT NULL
+                  AND LENGTH(mp3_data) > 10
+            """)
+            rows = cur.fetchall()
+            return [Song.from_row(row) for row in rows]
+        finally:
+            cur.close()
+            conn.close()
+
+    def get_by_id(self, song_id: int) -> Optional[Song]:
+        """
+        Busca una canción por ID incluyendo mp3_data para streaming.
+
+        Args:
+            song_id: ID de la canción a buscar.
+
+        Returns:
+            Song con mp3_data incluido, o None si no existe.
+        """
+        conn = get_db()
+        try:
+            cur = conn.cursor()
+            cur.execute("""
+                SELECT id, title, artist, mp3_data, created_at
+                FROM songs
+                WHERE id = %s
+            """, (song_id,))
+            row = cur.fetchone()
+            return Song.from_row(row) if row else None
+        finally:
+            cur.close()
+            conn.close()


### PR DESCRIPTION
Resumen (1 frase)
Se implementa SongRepository para manejar el acceso a datos de canciones desde la base de datos.
Tipo de cambio
[ ] Fix (corrección de bug)
[X] Feat (nueva funcionalidad)
[ ] Refactor (cambios internos sin cambiar comportamiento)
[ ] Docs (documentación)
[ ] Chore/CI (configuración, dependencias, pipeline)
[ ] Perf (mejora de rendimiento)
[ ] Test (tests)
[ ] No sé
Contexto / Problema
El backend necesita una capa de acceso a datos que permita realizar consultas a la base de datos relacionadas con las canciones.

Sin un repositorio dedicado, las consultas SQL quedarían dispersas en otras capas del sistema, dificultando el mantenimiento del código.
Solución propuesta
Antes

No existía una clase encargada de manejar las consultas de canciones.

Después

Se implementó la clase SongRepository que:

Permite obtener todas las canciones (get_all)

Permite obtener una canción por ID (get_by_id)

Filtra canciones con mp3_data válido

Convierte resultados de MySQL en objetos Song

Maneja correctamente el cierre de cursor y conexión

Cómo probarlo (pasos)
Ejecutar el backend.

Llamar al método get_all() desde SongRepository.

Verificar que devuelve una lista de objetos Song.

Llamar al método get_by_id(id).

Confirmar que devuelve la canción correspondiente.

Evidencia
Capturas/GIF: No aplica
Logs: No sé
Impacto / Riesgos
Cambios rompientes (breaking): No
Migraciones / scripts: No aplica
Seguridad / Privacidad: No sé
Riesgo percibido
[ x] Bajo
Medio
Alto
Motivo (opcional): No sé
Checklist antes de pedir review
[X] Probé localmente los casos principales
[ ] Agregué/actualicé tests o marqué “No aplica”
[X] Pasé linters/formatters
[ ] Actualicé documentación/README si corresponde
[X] Vinculé issues: closes #14 
[X] Añadí plan de QA o pasos reproducibles
Notas para quien revisa (opcional)
Archivos clave: Módulo de carga de biblioteca
Dudas: No aplica

label: Baja (cosmético, no afecta uso)
label: Media (afecta funcionalidad, pero hay workaround)
label: Alta (bloquea uso normal o causa pérdida de datos)
validations:
required: true