### PR TITLE
feat(repository): implement BackupRepository (#15)

### DIFF
--- a/broken-tunes-backend/app/repositories/Backup_repository.py
+++ b/broken-tunes-backend/app/repositories/Backup_repository.py
@@ -1,0 +1,90 @@
+from typing import Optional
+from app.database import get_db
+from app.models.Song import Song
+from app.models.Backup import Backup
+
+
+class BackupRepository:
+    """
+    Único punto de acceso a datos de la tabla 'songs_backup'.
+    Todas las queries relacionadas a backups viven aquí.
+    """
+
+    def get_all(self) -> list[Backup]:
+        """
+        Retorna todos los backups ordenados por fecha descendente.
+
+        Returns:
+            list[Backup]: Lista de backups sin mp3_data (solo metadata).
+        """
+        conn = get_db()
+        try:
+            cur = conn.cursor()
+            cur.execute("""
+                SELECT id, original_song_id, title, artist,
+                       backup_note, backed_up_by, backed_up_at
+                FROM songs_backup
+                ORDER BY backed_up_at DESC
+            """)
+            rows = cur.fetchall()
+            return [Backup.from_row(row) for row in rows]
+        finally:
+            cur.close()
+            conn.close()
+
+    def get_by_id(self, backup_id: int) -> Optional[Backup]:
+        """
+        Busca un backup por ID incluyendo mp3_data para streaming.
+
+        Args:
+            backup_id: ID del backup a buscar.
+
+        Returns:
+            Backup con mp3_data incluido, o None si no existe.
+        """
+        conn = get_db()
+        try:
+            cur = conn.cursor()
+            cur.execute("""
+                SELECT id, original_song_id, title, artist,
+                       backup_note, backed_up_by, backed_up_at, mp3_data
+                FROM songs_backup
+                WHERE id = %s
+            """, (backup_id,))
+            row = cur.fetchone()
+            if not row:
+                return None
+            backup = Backup.from_row(row)
+            backup.mp3_data = bytes(row[7]) if row[7] else None
+            return backup
+        finally:
+            cur.close()
+            conn.close()
+
+    def create(self, song: Song, backed_by: str, note: str) -> int:
+        """
+        Crea un backup de una canción existente en songs_backup.
+
+        Args:
+            song:      Instancia Song con mp3_data incluido.
+            backed_by: Usuario o sistema que genera el backup.
+            note:      Nota descriptiva del backup.
+
+        Returns:
+            int: ID del backup recién creado.
+        """
+        conn = get_db()
+        try:
+            cur = conn.cursor()
+            cur.execute("""
+                INSERT INTO songs_backup
+                    (original_song_id, title, artist, mp3_data,
+                     backup_note, backed_up_by, backed_up_at)
+                VALUES (%s, %s, %s, %s, %s, %s, NOW())
+            """, (song.id, song.title, song.artist,
+                  song.mp3_data, note, backed_by))
+            conn.commit()
+            return cur.lastrowid
+        finally:
+            cur.close()
+            conn.close()


### PR DESCRIPTION
Resumen (1 frase)
Se implementa BackupRepository para gestionar el acceso a datos de los respaldos de canciones almacenados en la tabla songs_backup.
Tipo de cambio
[ ] Fix (corrección de bug)
[X] Feat (nueva funcionalidad)
[ ] Refactor (cambios internos sin cambiar comportamiento)
[ ] Docs (documentación)
[ ] Chore/CI (configuración, dependencias, pipeline)
[ ] Perf (mejora de rendimiento)
[ ] Test (tests)
[ ] No sé
Contexto / Problema
El backend requiere una capa de acceso a datos que permita gestionar los respaldos de canciones almacenados en la tabla songs_backup.

Sin un repositorio dedicado, las consultas SQL relacionadas con los respaldos quedarían distribuidas en diferentes partes del sistema, dificultando su mantenimiento y organización.
Solución propuesta
Antes

No existía una clase encargada de manejar las consultas relacionadas con los respaldos de canciones.

Después

Se implementó la clase BackupRepository que permite:

Obtener todos los respaldos (get_all)

Obtener un respaldo por ID (get_by_id)

Crear un nuevo respaldo a partir de una canción (create)

Convertir resultados de MySQL en objetos Backup

Manejar correctamente el cierre de cursor y conexión

Cómo probarlo (pasos)
Ejecutar el backend.

Llamar al método get_all() desde BackupRepository.

Verificar que devuelve una lista de objetos Backup.

Llamar al método get_by_id(id) y confirmar que devuelve el respaldo correspondiente.

Probar el método create() para generar un nuevo respaldo de una canción.

Evidencia
Capturas/GIF: No aplica
Logs: No sé
Impacto / Riesgos
Cambios rompientes (breaking): No
Migraciones / scripts: No aplica
Seguridad / Privacidad: No sé
Riesgo percibido
[ x] Bajo
Medio
Alto
Motivo (opcional): No sé
Checklist antes de pedir review
[X] Probé localmente los casos principales
[ ] Agregué/actualicé tests o marqué “No aplica”
[X] Pasé linters/formatters
[ ] Actualicé documentación/README si corresponde
[X] Vinculé issues: closes #15 
[X] Añadí plan de QA o pasos reproducibles
Notas para quien revisa (opcional)
Archivos clave: Módulo de carga de biblioteca
Dudas: No aplica

label: Baja (cosmético, no afecta uso)
label: Media (afecta funcionalidad, pero hay workaround)
label: Alta (bloquea uso normal o causa pérdida de datos)
validations:
required: true