### PR TITLE
feat(controller): implement SongController (#16)

### DIFF
--- a/broken-tunes-backend/app/controllers/Song_controller.py
+++ b/broken-tunes-backend/app/controllers/Song_controller.py
@@ -1,0 +1,39 @@
+from typing import Optional
+from app.repositories.Song_repository import SongRepository
+
+_repo = SongRepository()
+
+
+class SongController:
+    """
+    Lógica de negocio relacionada a canciones.
+    No importa flask, request ni Response.
+    Llama al repositorio y retorna datos serializables.
+    """
+
+    def list_songs(self) -> list[dict]:
+        """
+        Retorna todas las canciones con audio válido como lista de dicts.
+
+        Returns:
+            list[dict]: Metadata de canciones lista para jsonify().
+        """
+        songs = _repo.get_all()
+        return [song.to_dict() for song in songs]
+
+    def stream_song(self, song_id: int) -> Optional[tuple[bytes, str]]:
+        """
+        Obtiene los bytes de audio y el nombre de archivo de una canción.
+
+        Args:
+            song_id: ID de la canción a reproducir.
+
+        Returns:
+            tuple[bytes, str]: (mp3_data, filename) si existe.
+            None si la canción no existe o no tiene audio.
+        """
+        song = _repo.get_by_id(song_id)
+        if not song or not song.mp3_data:
+            return None
+        filename = f"{song.title}.mp3"
+        return song.mp3_data, filename


### PR DESCRIPTION
Resumen (1 frase)
Se implementa SongController para manejar la lógica de negocio de canciones, incluyendo listado y streaming de audio.
Tipo de cambio
[ ] Fix (corrección de bug)
[X] Feat (nueva funcionalidad)
[ ] Refactor (cambios internos sin cambiar comportamiento)
[ ] Docs (documentación)
[ ] Chore/CI (configuración, dependencias, pipeline)
[ ] Perf (mejora de rendimiento)
[ ] Test (tests)
[ ] No sé
Contexto / Problema
El backend necesita una capa de lógica de negocio que gestione las operaciones relacionadas con las canciones.

Sin un controlador dedicado, la lógica para obtener canciones y preparar el audio para streaming quedaría dispersa en diferentes partes del sistema.
Solución propuesta
Antes

No existía una clase encargada de manejar la lógica de canciones.

Después

Se implementó la clase SongController que permite:

Obtener la lista de canciones (list_songs)

Preparar datos serializables para respuestas JSON

Preparar el audio de una canción para streaming (stream_song)

Utilizar SongRepository para acceder a los datos
Cómo probarlo (pasos)
Ejecutar el backend.

Llamar al método list_songs() desde SongController.

Verificar que devuelve una lista de canciones serializadas.

Llamar al método stream_song(id) para una canción existente.

Confirmar que se obtiene el audio preparado para streaming

Evidencia
Capturas/GIF: No aplica
Logs: No sé
Impacto / Riesgos
Cambios rompientes (breaking): No
Migraciones / scripts: No aplica
Seguridad / Privacidad: No sé
Riesgo percibido
[ x] Bajo
Medio
Alto
Motivo (opcional): No sé
Checklist antes de pedir review
[X] Probé localmente los casos principales
[ ] Agregué/actualicé tests o marqué “No aplica”
[X] Pasé linters/formatters
[ ] Actualicé documentación/README si corresponde
[X] Vinculé issues: closes #16 
[X] Añadí plan de QA o pasos reproducibles
Notas para quien revisa (opcional)
Archivos clave: Módulo de carga de biblioteca
Dudas: No aplica

label: Baja (cosmético, no afecta uso)
label: Media (afecta funcionalidad, pero hay workaround)
label: Alta (bloquea uso normal o causa pérdida de datos)
validations:
required: true