### PR TITLE
feat(routes): implement song endpoints (#18)

### DIFF
--- a/broken-tunes-backend/app/routes/Song_routes.py
+++ b/broken-tunes-backend/app/routes/Song_routes.py
@@ -1,0 +1,34 @@
+from flask import Blueprint, jsonify, Response, abort
+from app.controllers.Song_controller import SongController
+
+songs_bp = Blueprint('songs', __name__)
+_controller = SongController()
+
+
+@songs_bp.route('/api/songs')
+def api_songs():
+    """
+    GET /api/songs
+    Retorna lista de canciones con audio válido.
+    """
+    return jsonify(_controller.list_songs())
+
+
+@songs_bp.route('/play/<int:song_id>')
+def play_song(song_id: int):
+    """
+    GET /play/<song_id>
+    Sirve el audio MP3 de una canción para streaming.
+    """
+    result = _controller.stream_song(song_id)
+    if not result:
+        abort(404)
+
+    mp3_data, filename = result
+    return Response(
+        mp3_data,
+        mimetype='audio/mpeg',
+        headers={
+            'Content-Disposition': f'inline; filename="{filename}"'
+        }
+    )


### PR DESCRIPTION
Resumen (1 frase)
Se implementan los endpoints REST para consumir canciones, permitiendo listar canciones disponibles y reproducir audio en streaming.
Tipo de cambio
[ ] Fix (corrección de bug)
[X] Feat (nueva funcionalidad)
[ ] Refactor (cambios internos sin cambiar comportamiento)
[ ] Docs (documentación)
[ ] Chore/CI (configuración, dependencias, pipeline)
[ ] Perf (mejora de rendimiento)
[ ] Test (tests)
[ ] No sé
Contexto / Problema
El backend necesita exponer endpoints REST que permitan a los clientes consumir la información de canciones y reproducirlas.

Sin estas rutas, no es posible acceder desde el frontend o desde clientes externos a la lista de canciones ni reproducir el audio almacenado en la base de datos.
Solución propuesta
Antes

No existían rutas API para acceder a las canciones ni para reproducir audio.

Después

Se implementaron las rutas en Song_routes.py que permiten:

Obtener la lista de canciones disponibles (GET /api/songs)

Reproducir una canción mediante streaming (GET /play/<id>)

Utilizar SongController para manejar la lógica de negocio

Preparar las respuestas en formato JSON

Enviar audio en streaming al cliente
Cómo probarlo (pasos)
Ejecutar el backend.

Realizar una petición a:

GET /api/songs

Verificar que devuelve una lista de canciones disponibles.

Realizar una petición a:

GET /play/<id>

Confirmar que se reproduce la canción correspondiente en streaming.

Evidencia
Capturas/GIF: No aplica
Logs: No sé
Impacto / Riesgos
Cambios rompientes (breaking): No
Migraciones / scripts: No aplica
Seguridad / Privacidad: No sé
Riesgo percibido
[ x] Bajo
Medio
Alto
Motivo (opcional): No sé
Checklist antes de pedir review
[X] Probé localmente los casos principales
[ ] Agregué/actualicé tests o marqué “No aplica”
[X] Pasé linters/formatters
[ ] Actualicé documentación/README si corresponde
[X] Vinculé issues: closes #18 
[X] Añadí plan de QA o pasos reproducibles
Notas para quien revisa (opcional)
Archivos clave: Módulo de carga de biblioteca
Dudas: No aplica

label: Baja (cosmético, no afecta uso)
label: Media (afecta funcionalidad, pero hay workaround)
label: Alta (bloquea uso normal o causa pérdida de datos)
validations:
required: true