### PR TITLE
feat(routes): implement backup endpoints (#32)

### DIFF
--- a/broken-tunes-backend/app/routes/Backup_routes.py
+++ b/broken-tunes-backend/app/routes/Backup_routes.py
@@ -1,0 +1,35 @@
+from flask import Blueprint, jsonify, request
+from app.controllers.Backup_controller import BackupController
+
+backups_bp = Blueprint('backups', __name__)
+_controller = BackupController()
+
+
+@backups_bp.route('/api/songs_backup')
+def api_songs_backup():
+    """
+    GET /api/songs_backup
+    Retorna lista de backups ordenados por fecha descendente.
+    """
+    return jsonify(_controller.list_backups())
+
+
+@backups_bp.route('/api/backup/<int:song_id>', methods=['POST'])
+def api_backup_song(song_id: int):
+    """
+    POST /api/backup/<song_id>
+    Crea un backup de la canción indicada.
+
+    Form data:
+        backed_by (str): Usuario que genera el backup. Default: 'web-ui'
+        note      (str): Nota descriptiva.            Default: 'manual backup'
+    """
+    backed_by = request.form.get('backed_by', 'web-ui')
+    note      = request.form.get('note', 'manual backup')
+
+    result = _controller.create_backup(song_id, backed_by, note)
+
+    if not result['ok']:
+        return jsonify(result), 404
+
+    return jsonify(result)


### PR DESCRIPTION
Resumen (1 frase)
Se implementan los endpoints REST para gestionar respaldos de canciones, permitiendo consultar backups existentes y crear nuevos respaldos desde una canción.streaming.
Tipo de cambio
[ ] Fix (corrección de bug)
[X] Feat (nueva funcionalidad)
[ ] Refactor (cambios internos sin cambiar comportamiento)
[ ] Docs (documentación)
[ ] Chore/CI (configuración, dependencias, pipeline)
[ ] Perf (mejora de rendimiento)
[ ] Test (tests)
[ ] No sé
Contexto / Problema
El backend necesita exponer endpoints REST que permitan gestionar los respaldos de canciones almacenados en la base de datos.

Sin estas rutas, no es posible consultar los backups existentes ni crear nuevos respaldos desde el frontend o desde clientes externos.
Solución propuesta
Antes

No existían rutas API para consultar ni crear respaldos de canciones.

Después

Se implementaron las rutas en Backup_routes.py que permiten:

Obtener la lista de respaldos disponibles (GET /api/songs_backup)

Crear un respaldo de una canción (POST /api/backup/<song_id>)

Utilizar BackupController para manejar la lógica de negocio

Preparar las respuestas en formato JSON

Validar la existencia de la canción antes de crear el respaldo
Cómo probarlo (pasos)
Ejecutar el backend.

Realizar una petición a:

GET /api/songs_backup

Verificar que devuelve una lista de respaldos ordenados por fecha.

Realizar una petición a:

POST /api/backup/<song_id>

Enviar en Form Data:

backed_by = web-ui
note = manual backup

Confirmar que se crea correctamente el respaldo de la canción.
Evidencia
Capturas/GIF: No aplica
Logs: No sé
Impacto / Riesgos
Cambios rompientes (breaking): No
Migraciones / scripts: No aplica
Seguridad / Privacidad: No sé
Riesgo percibido
[ x] Bajo
Medio
Alto
Motivo (opcional): No sé
Checklist antes de pedir review
[X] Probé localmente los casos principales
[ ] Agregué/actualicé tests o marqué “No aplica”
[X] Pasé linters/formatters
[ ] Actualicé documentación/README si corresponde
[X] Vinculé issues: closes #32 
[X] Añadí plan de QA o pasos reproducibles
Notas para quien revisa (opcional)
Archivos clave: Módulo de carga de biblioteca
Dudas: No aplica

label: Baja (cosmético, no afecta uso)
label: Media (afecta funcionalidad, pero hay workaround)
label: Alta (bloquea uso normal o causa pérdida de datos)
validations:
required: true