### PR TITLE
feat(auth): implement login endpoint (#33)

### DIFF
--- a/broken-tunes-backend/app/routes/Auth_routes.py
+++ b/broken-tunes-backend/app/routes/Auth_routes.py
@@ -1,0 +1,40 @@
+from flask import Blueprint, jsonify, request
+from werkzeug.security import check_password_hash
+from app.database import get_db
+
+auth_bp = Blueprint('auth', __name__)
+
+
+@auth_bp.route('/login', methods=['POST'])
+def login():
+    """
+    POST /login
+    Autentica un usuario por username y password.
+
+    Form data:
+        username (str)
+        password (str)
+
+    Returns:
+        {'ok': True,  'username': str} con status 200 si es válido.
+        {'ok': False}                  con status 401 si no es válido.
+    """
+    username = request.form.get('username', '')
+    password = request.form.get('password', '')
+
+    conn = get_db()
+    try:
+        cur = conn.cursor()
+        cur.execute(
+            "SELECT id, password FROM users WHERE username = %s",
+            (username,)
+        )
+        row = cur.fetchone()
+    finally:
+        cur.close()
+        conn.close()
+
+    if row and check_password_hash(row[1], password):
+        return jsonify({'ok': True, 'username': username})
+
+    return jsonify({'ok': False}), 401


### PR DESCRIPTION
Resumen (1 frase)
Se implementa el endpoint REST de autenticación de usuarios, permitiendo validar credenciales mediante username y password.
Tipo de cambio
[ ] Fix (corrección de bug)
[X] Feat (nueva funcionalidad)
[ ] Refactor (cambios internos sin cambiar comportamiento)
[ ] Docs (documentación)
[ ] Chore/CI (configuración, dependencias, pipeline)
[ ] Perf (mejora de rendimiento)
[ ] Test (tests)
[ ] No sé
Contexto / Problema
El backend necesita un endpoint de autenticación que permita verificar las credenciales de los usuarios registrados en la base de datos.

Sin este endpoint, no es posible autenticar usuarios desde el frontend ni validar el acceso al sistema.
Solución propuesta
Antes

No existía un endpoint para autenticar usuarios mediante username y password.

Después

Se implementó una ruta en Auth_routes.py que permite:

Autenticar usuarios mediante el endpoint POST /login

Consultar la tabla users en la base de datos

Verificar la contraseña utilizando check_password_hash

Retornar respuestas en formato JSON

Devolver estado 401 cuando las credenciales son inválidas
Cómo probarlo (pasos)
Ejecutar el backend.

Realizar una petición a:

POST /login

Enviar en Form Data:

username = usuario
password = contraseña

Evidencia
Capturas/GIF: No aplica
Logs: No sé
Impacto / Riesgos
Cambios rompientes (breaking): No
Migraciones / scripts: No aplica
Seguridad / Privacidad: No sé
Riesgo percibido
[ x] Bajo
Medio
Alto
Motivo (opcional): No sé
Checklist antes de pedir review
[X] Probé localmente los casos principales
[ ] Agregué/actualicé tests o marqué “No aplica”
[X] Pasé linters/formatters
[ ] Actualicé documentación/README si corresponde
[X] Vinculé issues: closes #33 
[X] Añadí plan de QA o pasos reproducibles
Notas para quien revisa (opcional)
Archivos clave: Módulo de carga de biblioteca
Dudas: No aplica

label: Baja (cosmético, no afecta uso)
label: Media (afecta funcionalidad, pero hay workaround)
label: Alta (bloquea uso normal o causa pérdida de datos)
validations:
required: true