### PR TITLE
test(api): add backend endpoint tests with pytest (#21)

### DIFF
--- a/broken-tunes-backend/tests/conftest.py
+++ b/broken-tunes-backend/tests/conftest.py
@@ -1,0 +1,14 @@
+import sys
+import os
+
+# Agrega la raíz del proyecto al PYTHONPATH
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pytest
+from app import app
+
+@pytest.fixture
+def client():
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        yield client

--- a/broken-tunes-backend/tests/test_api_songs.py
+++ b/broken-tunes-backend/tests/test_api_songs.py
@@ -1,0 +1,76 @@
+from unittest.mock import MagicMock, patch
+import json
+
+def test_api_songs_status(client):
+    assert client.get('/api/songs').status_code == 200
+
+def test_api_songs_is_list(client):
+    assert isinstance(client.get('/api/songs').json, list)
+
+def test_api_songs_empty(client, monkeypatch):
+    class C:
+        def execute(self, q): pass
+        def fetchall(self): return []
+        def close(self): pass
+    class DB:
+        def cursor(self): return C()
+        def close(self): pass
+
+    monkeypatch.setattr('app.get_db', lambda: DB())
+    assert client.get('/api/songs').json == []
+
+@patch('app.get_db')
+def test_api_songs_mocked(mock_db, client):
+    cur = MagicMock()
+    cur.fetchall.return_value = [(1, 'A', 'B')]
+    conn = MagicMock()
+    conn.cursor.return_value = cur
+    mock_db.return_value = conn
+
+    r = client.get('/api/songs')
+    assert r.json[0]['title'] == 'A'
+
+def test_api_songs_fields(client):
+    r = client.get('/api/songs')
+    if r.json:
+        assert set(r.json[0].keys()) == {'id', 'title', 'artist'}
+
+def test_api_songs_types(client):
+    r = client.get('/api/songs')
+    if r.json:
+        assert isinstance(r.json[0]['id'], int)
+
+def test_api_songs_no_html(client):
+    r = client.get('/api/songs')
+    if r.json:
+        assert '<' not in r.json[0]['title']
+
+def test_api_songs_get_only(client):
+    assert client.post('/api/songs').status_code == 405
+
+def test_api_songs_json_serializable(client):
+    json.dumps(client.get('/api/songs').json)
+
+def test_api_songs_large_querystring(client):
+    r = client.get('/api/songs?' + 'x' * 5000)
+    assert r.status_code in (200, 400)
+
+def test_api_songs_twice(client):
+    r1 = client.get('/api/songs')
+    r2 = client.get('/api/songs')
+    assert r1.status_code == r2.status_code
+
+def test_api_songs_response_is_list(client):
+    assert isinstance(client.get('/api/songs').json, list)
+
+def test_unknown_method_on_songs(client):
+    assert client.put('/api/songs').status_code in (400, 405)
+
+def test_delete_not_allowed(client):
+    assert client.delete('/api/songs').status_code in (400, 405)
+
+def test_json_not_html(client):
+    assert 'text/html' not in client.get('/api/songs').content_type
+
+def test_json_content_type(client):
+    assert 'application/json' in client.get('/api/songs').content_type

--- a/broken-tunes-backend/tests/test_backup.py
+++ b/broken-tunes-backend/tests/test_backup.py
@@ -1,0 +1,61 @@
+from unittest.mock import MagicMock, patch
+
+def test_backup_not_found(client):
+    assert client.post('/api/backup/999').status_code == 404
+
+@patch('app.get_db')
+def test_backup_ok(mock_db, client):
+    cur = MagicMock()
+    cur.fetchone.return_value = (1, 'Song', 'Artist', b'123')
+    cur.lastrowid = 5
+    conn = MagicMock()
+    conn.cursor.return_value = cur
+    mock_db.return_value = conn
+
+    r = client.post('/api/backup/1')
+    assert r.json['ok'] is True
+
+def test_backup_get_not_allowed(client):
+    assert client.get('/api/backup/1').status_code == 405
+
+def test_backup_default_values(client):
+    assert client.post('/api/backup/999').status_code == 404
+
+@patch('app.get_db')
+def test_backup_commit_called(mock_db, client):
+    cur = MagicMock()
+    cur.fetchone.return_value = (1, 'Song', 'Artist', b'123')
+    conn = MagicMock()
+    conn.cursor.return_value = cur
+    mock_db.return_value = conn
+
+    client.post('/api/backup/1')
+    conn.commit.assert_called_once()
+
+def test_backup_json(client):
+    assert client.post('/api/backup/999').is_json
+
+def test_backup_form_data(client):
+    assert client.post('/api/backup/999', data={'note': 'x'}).status_code == 404
+
+def test_backup_numeric_id(client):
+    assert client.post('/api/backup/1').status_code in (200, 404)
+
+def test_backup_invalid_method(client):
+    assert client.put('/api/backup/1').status_code == 405
+
+def test_backup_response_type(client):
+    r = client.post('/api/backup/999')
+    assert isinstance(r.json, dict)
+
+def test_backup_without_id(client):
+    assert client.post('/api/backup/').status_code in (404, 405)
+
+def test_api_backup_sql_injection(client):
+    r = client.post('/api/backup/1 OR 1=1')
+    assert r.status_code in (400, 404, 405)
+
+def test_backup_returns_json(client):
+    r = client.post('/api/backup/1')
+    if r.status_code == 200:
+        assert r.is_json

--- a/broken-tunes-backend/tests/test_db_mock.py
+++ b/broken-tunes-backend/tests/test_db_mock.py
@@ -1,0 +1,50 @@
+from unittest.mock import MagicMock, patch
+
+@patch('app.get_db')
+def test_db_cursor_used(mock_db, client):
+    conn = MagicMock()
+    mock_db.return_value = conn
+    client.get('/api/songs')
+    conn.cursor.assert_called()
+
+@patch('app.get_db')
+def test_db_closed(mock_db, client):
+    conn = MagicMock()
+    mock_db.return_value = conn
+    client.get('/api/songs')
+    conn.close.assert_called()
+
+@patch('app.get_db')
+def test_cursor_close(mock_db, client):
+    cur = MagicMock()
+    conn = MagicMock()
+    conn.cursor.return_value = cur
+    mock_db.return_value = conn
+    client.get('/api/songs')
+    cur.close.assert_called()
+
+@patch('app.get_db')
+def test_fetchall_called(mock_db, client):
+    cur = MagicMock()
+    cur.fetchall.return_value = []
+    conn = MagicMock()
+    conn.cursor.return_value = cur
+    mock_db.return_value = conn
+    client.get('/api/songs')
+    cur.fetchall.assert_called()
+
+@patch('app.get_db')
+def test_execute_called(mock_db, client):
+    cur = MagicMock()
+    cur.fetchall.return_value = []
+    conn = MagicMock()
+    conn.cursor.return_value = cur
+    mock_db.return_value = conn
+    client.get('/api/songs')
+    cur.execute.assert_called()
+
+@patch('app.get_db')
+def test_db_exception_handled(mock_db, client):
+    mock_db.side_effect = Exception("DB Down")
+    r = client.get('/api/songs')
+    assert r.status_code == 500

--- a/broken-tunes-backend/tests/test_play.py
+++ b/broken-tunes-backend/tests/test_play.py
@@ -1,0 +1,55 @@
+from unittest.mock import MagicMock, patch
+
+@patch('app.get_db')
+def test_play_ok(mock_db, client):
+    cur = MagicMock()
+    cur.fetchone.return_value = (1, 'Song', 'Artist', b'123', None)
+    conn = MagicMock()
+    conn.cursor.return_value = cur
+    mock_db.return_value = conn
+
+    assert client.get('/play/1').status_code == 200
+
+def test_play_not_found(client):
+    assert client.get('/play/9999').status_code == 404
+
+@patch('app.get_db')
+def test_play_mimetype(mock_db, client):
+    cur = MagicMock()
+    cur.fetchone.return_value = (1, 'Song', 'Artist', b'123', None)
+    conn = MagicMock()
+    conn.cursor.return_value = cur
+    mock_db.return_value = conn
+
+    assert client.get('/play/1').content_type == 'audio/mpeg'
+
+def test_play_invalid_id(client):
+    assert client.get('/play/abc').status_code in (400, 404)
+
+@patch('app.get_db')
+def test_play_empty_blob(mock_db, client):
+    cur = MagicMock()
+    cur.fetchone.return_value = (1, 'Song', 'Artist', b'', None)
+    conn = MagicMock()
+    conn.cursor.return_value = cur
+    mock_db.return_value = conn
+
+    assert client.get('/play/1').status_code == 200
+
+def test_play_sql_injection(client):
+    assert client.get('/play/1 OR 1=1').status_code in (400, 404)
+
+def test_play_method_not_allowed(client):
+    assert client.post('/play/1').status_code == 405
+
+def test_play_sql_like_input(client):
+    assert client.get('/play/1 OR 1=1').status_code in (200, 400, 404)
+
+def test_play_encoded_sql_input(client):
+    assert client.get('/play/1%20OR%201=1').status_code in (200, 400, 404)
+
+def test_play_path_traversal(client):
+    assert client.get('/play/../../etc/passwd').status_code in (400, 404)
+
+def test_play_invalid_characters(client):
+    assert client.get('/play/!!!!').status_code < 500

--- a/broken-tunes-backend/tests/test_security.py
+++ b/broken-tunes-backend/tests/test_security.py
@@ -1,0 +1,2 @@
+def test_unknown_route(client):
+    assert client.get('/nope').status_code == 404


### PR DESCRIPTION
Resumen (1 frase)
Se implementan pruebas unitarias utilizando pytest para validar el funcionamiento de los endpoints principales del backend.
Tipo de cambio
[ ] Fix (corrección de bug)
[ ] Feat (nueva funcionalidad)
[ ] Refactor (cambios internos sin cambiar comportamiento)
[ ] Docs (documentación)
[ ] Chore/CI (configuración, dependencias, pipeline)
[ ] Perf (mejora de rendimiento)
[X] Test (tests)
[ ] No sé
Contexto / Problema
El backend expone varios endpoints REST que permiten consultar canciones, reproducir audio y crear respaldos.

Sin pruebas automatizadas, no existe una forma confiable de verificar que estos endpoints funcionen correctamente ni de detectar errores cuando se realizan cambios en el código.
Solución propuesta
Antes

No existían pruebas automatizadas para validar el funcionamiento de los endpoints del backend.

Después

Se implementaron pruebas unitarias utilizando pytest dentro de la carpeta tests/ que permiten:

Verificar el endpoint GET /api/songs

Probar el endpoint GET /play/

Validar la creación de respaldos mediante POST /api/backup/

Comprobar la conexión a la base de datos

Validar el comportamiento ante rutas inválidas

Las pruebas permiten verificar que el backend responda correctamente y detectar errores de manera temprana durante el desarrollo.
Cómo probarlo (pasos)
Instalar dependencias necesarias:

pip install pytest

2️⃣ Ejecutar las pruebas:

pytest

3️⃣ Verificar que:

Las pruebas de los endpoints se ejecutan correctamente.

Los endpoints responden con los códigos de estado esperados.

Las rutas inválidas devuelven errores apropiados.
Evidencia
Capturas/GIF: No aplica
Logs: No sé
Impacto / Riesgos
Cambios rompientes (breaking): No
Migraciones / scripts: No aplica
Seguridad / Privacidad: No sé
Riesgo percibido
[ x] Bajo
Medio
Alto
Motivo (opcional): No sé
Checklist antes de pedir review
[X] Probé localmente los casos principales
[X] Agregué/actualicé tests
[X] Pasé linters/formatters
[ ] Actualicé documentación/README si corresponde
[X] Vinculé issues: closes #21 
[X] Añadí plan de QA o pasos reproducibles
Notas para quien revisa (opcional)
Archivos clave: Módulo de carga de biblioteca
Dudas: No aplica

label: Baja (cosmético, no afecta uso)
label: Media (afecta funcionalidad, pero hay workaround)
label: Alta (bloquea uso normal o causa pérdida de datos)
validations:
required: true